### PR TITLE
Swapped out distutils.core with setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup, find_packages
 
 setup(
     name='python-etsy',


### PR DESCRIPTION
appears that intall_requires function is part of the setuptools module
and part of the find_packages module, so I swapped out the first import
line for one that should work for everyone a little better. 

I'm still an extremely new python developer, but from what I saw that distutils.core doesn't include functions for being able to find_packages on it's own swapping out that change made it work just fine. 